### PR TITLE
ci(dev-track-test): only test when tracks exist

### DIFF
--- a/.github/workflows/dev-track-test.yml
+++ b/.github/workflows/dev-track-test.yml
@@ -46,6 +46,7 @@ jobs:
 
   TestDevTracks:
     runs-on: ubuntu-latest
+    if: ${{ needs.GetTrackSlugs.outputs.matrix != '[]' && needs.GetTrackSlugs.outputs.matrix != '' }}
     needs: GetTrackSlugs
     strategy:
       matrix: ${{ fromJson(needs.GetTrackSlugs.outputs.matrix) }}


### PR DESCRIPTION
It uses the [same method as the `prod-track-test` workflow](https://github.com/instruqt/skeleton/blob/21511e5ab7ba2aac1e9fbd1dde980c4acf18cfa8/.github/workflows/prod-track-test.yml#L61) to only run the `TestDevTracks` when there are tracks (i.e., the `GetTrackSlugs.outputs.matrix` output is populated).