### PR TITLE
Check for "-dev" at the END of the slug

### DIFF
--- a/.github/actions/track-dev/action.yml
+++ b/.github/actions/track-dev/action.yml
@@ -13,7 +13,7 @@ runs:
       cd ${{ inputs.path }}
 
       # Check whether this is already a dev version track
-      ISDEV=$(yq '.slug | contains("-dev")' track.yml)
+      ISDEV=$(yq '.slug | test(".*-dev$")' track.yml)
       if [[ $ISDEV == "true" ]]; then
         echo -e "It looks like the track slug already has the -dev suffix"
         exit 1


### PR DESCRIPTION
Test the end of the slug to prevent matching on tracks with "-dev" in the middle of the string.
For example: "learn-to-develop-with-instruqt" should not be a match for the `ISDEV` test. 