### PR TITLE
Update test-dev-tracks.yml

### DIFF
--- a/.github/workflows/test-dev-tracks.yml
+++ b/.github/workflows/test-dev-tracks.yml
@@ -128,7 +128,7 @@ jobs:
           # Replace prod tag with dev tag
           yq eval --inplace 'del(.tags[] | select(. == "prod"))' track.yml
           yq eval --inplace '.tags = .tags + "dev" ' track.yml
-
+        continue-on-error: true
       # Then, we attempt to pull these DEV tracks from the Instruqt platform.
       # This ensures you get the latest version of the dev track.
       # Only dev tracks that are not in maintenance mode are tested!


### PR DESCRIPTION
Added a line 131: continue-on-error: true
Made a change in the file **test-dev-tracks.yml** as the workflow gives an error while creating the dev track from the prod track when the track contains no-ci, ci-skip, or skip-ci.